### PR TITLE
使用普通 for 循环来遍历数组

### DIFF
--- a/js/bootstrap-ie.js
+++ b/js/bootstrap-ie.js
@@ -127,8 +127,8 @@
       // dropdown 
       //-------------
       // fix for IE6 not support li:hover
-      var lis = ['dropdown-submenu'];
-      for (var i in lis) {
+      var i, lis = ['dropdown-submenu'];
+      for (i = 0; i < lis.length; i++) {
         var child = 'li.' + lis[i];
         var hover = lis[i] + '-hover';
         $('ul', el).on('mouseenter', child, function () {


### PR DESCRIPTION
Hi，@ddouble，今天用 bsie 的时候，发现了一个问题。

现象是，在IE6上， `li` 一旦触发 `mouseenter` 就会报错。

查看了一番，发现是这样的。有些项目（比如我正在做的）会引入 html5shim 之类的库，这样在 IE 低版本的浏览器上会为 Array 增加一些函数（ forEach、indexOf...），而用 `for...in...` 来遍历数组的话，就会把新增加的函数也会当做一个 item，这个时候一般都会导致报错。

所以我提交了一个 pull request，用 `for (int i = 0; i < length; i++)` 的形式来循环。
