### PR TITLE
Fix Grid incorrect margin-left of .offset*

### DIFF
--- a/bootstrap/less-ie6/mixins.less
+++ b/bootstrap/less-ie6/mixins.less
@@ -583,6 +583,7 @@
 
     .span-grid (@columns) {
       float: left;
+      display: inline;
       min-height: 1px; // prevent collapsing columns
       margin-left: @gridGutterWidth;
 

--- a/js/bootstrap-ie.js
+++ b/js/bootstrap-ie.js
@@ -121,7 +121,6 @@
       //-------------
       // GRID
       //-------------
-      $('.row-fluid [class*="span"]:first-child, .row [class*="span"]:first-child').addClass('span-first-child');
 
       //-------------
       // dropdown 


### PR DESCRIPTION
If an element has both `span*` and `offset*` classes, and it also fits `:first-child`, the offset\* class won't work.

What's more, elements, not `:first-child`, with `offset*` and `span*` have double margin-left too.

As mentioned in #14, this problem blames to the "ie6-double-margin" problem. To solve this problem, just add `display: inline;` to the element in IE6.
